### PR TITLE
Minimum docker support to avoid dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:7.4-cli as recalendar
+RUN apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY . /usr/src/recalendar
+WORKDIR /usr/src/recalendar
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+RUN composer install
+RUN php ./generate.php
+
+FROM scratch AS export-stage
+COPY --from=recalendar /usr/src/recalendar/ReCalendar.pdf .

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Put your custom `local.config.php` (if needed) in the root directory, and run:
   docker build --file Dockerfile . --output .
 ```
 
-First run will be slow because will compile & install and `composer`, but next calls will be faster.
+First run will be slow because it must compile & install `composer`, but next calls will be faster.
 
 You'll get the result in a `ReCalendar.pdf` file in the same directory.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,19 @@ Don't want to/need to/can customize it? Check out the [ready-to-use blank versio
  - Track your habits monthly.
  - Start the "year" on arbitrary month (can be useful for tracking academic years, etc.).
 
-## Quickstart
+## Quickstart with Docker
+
+Put your custom `local.config.php` (if needed) in the root directory, and run:
+
+```
+  docker build --file Dockerfile . --output .
+```
+
+First run will be slow because will compile & install and `composer`, but next calls will be faster.
+
+You'll get the result in a `ReCalendar.pdf` file in the same directory.
+
+## Quickstart without Docker
 
 Dependencies:
 


### PR DESCRIPTION
Just added a Dockerfile so I can use your incredible tool without installing composer and php in my Mac ;)
Not the perfect implementation, though. It "builds" a new image just to run the script, when it would be better to have an "official" image and run the whole process with just `docker run`, but I had no time, sorry.

Thanks for your work!